### PR TITLE
Use Composer to install Drush

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,15 @@ RUN yum -y install /opt/rpms/ImageMagick-6.8.9-10.x86_64.rpm /opt/rpms/ImageMagi
 RUN pip install --upgrade pip
 RUN pip install meld3==1.0.1 supervisor supervisor-stdout
 
-# Set up PHP date handling and Drush 5.10.
-RUN cat /usr/share/zoneinfo/US/Eastern > /etc/localtime && \
-    pear channel-discover pear.drush.org && \
-    pear install drush/drush-5.10.0.0
+# Set up PHP date handling
+RUN cat /usr/share/zoneinfo/US/Eastern > /etc/localtime
+
+# Setup Drush using Composer
+RUN echo "allow_url_fopen = On" >> /etc/php.ini
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+ENV PATH "/root/.composer/vendor/bin:$PATH"
+RUN composer global require drush/drush:7.1.0
 
 # Install PECL packages
 RUN yum -y install @"Development Tools"


### PR DESCRIPTION
- The Pear channel is no longer supported for installing Drush.
  Details at: https://www.drupal.org/node/2132447
- Use Composer to install Drush instead.
- There is not a pinned release for Drush 5.10. Use the current
  / latest supported version of Drush for PHP 5.3 (Drush 7.1.0).
